### PR TITLE
simplify slice expr (avoid len)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,19 +26,3 @@ jobs:
 
     - name: Test
       run: go test -v ./...
-
-  lint:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '1.22'
-          cache: false
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.56.0
-          args: --timeout 3m --config .golangci.yaml

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,5 +27,18 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-    - name: Golangci-lint
-      uses: golangci/golangci-lint-action@v6.0.1
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.56.0
+          args: --timeout 3m --config .golangci.yaml

--- a/formatter/fmt.go
+++ b/formatter/fmt.go
@@ -9,6 +9,7 @@ import (
 // rule set
 const (
 	UnnecessaryElse = "unnecessary-else"
+	SimplifySliceExpr = "simplify-slice-range"
 )
 
 // IssueFormatter is the interface that wraps the Format method.
@@ -36,6 +37,8 @@ func getFormatter(rule string) IssueFormatter {
 	switch rule {
 	case UnnecessaryElse:
 		return &UnnecessaryElseFormatter{}
+	case SimplifySliceExpr:
+		return &SimplifySliceExpressionFormatter{}
 	default:
 		return &GeneralIssueFormatter{}
 	}

--- a/formatter/fmt.go
+++ b/formatter/fmt.go
@@ -1,14 +1,16 @@
 package formatter
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/gnoswap-labs/lint/internal"
 )
 
 // rule set
 const (
-	UnnecessaryElse = "unnecessary-else"
+	UnnecessaryElse   = "unnecessary-else"
 	SimplifySliceExpr = "simplify-slice-range"
 )
 
@@ -49,4 +51,17 @@ func getFormatter(rule string) IssueFormatter {
 func formatIssueHeader(issue internal.Issue) string {
 	return errorStyle.Sprint("error: ") + ruleStyle.Sprint(issue.Rule) + "\n" +
 		lineStyle.Sprint(" --> ") + fileStyle.Sprint(issue.Filename) + "\n"
+}
+
+func buildSuggestion(result *strings.Builder, issue internal.Issue, lineStyle, suggestionStyle *color.Color) {
+	result.WriteString(suggestionStyle.Sprintf("Suggestion:\n"))
+	result.WriteString(lineStyle.Sprintf("%d | ", issue.Start.Line))
+	result.WriteString(fmt.Sprintf("%s\n", issue.Suggestion))
+	result.WriteString("\n")
+}
+
+func buildNote(result *strings.Builder, issue internal.Issue, suggestionStyle *color.Color) {
+	result.WriteString(suggestionStyle.Sprint("Note: "))
+	result.WriteString(fmt.Sprintf("%s\n", issue.Note))
+	result.WriteString("\n")
 }

--- a/formatter/simplify_slice_expr.go
+++ b/formatter/simplify_slice_expr.go
@@ -1,0 +1,1 @@
+package formatter

--- a/formatter/simplify_slice_expr.go
+++ b/formatter/simplify_slice_expr.go
@@ -1,1 +1,39 @@
 package formatter
+
+import (
+    "fmt"
+    "strings"
+
+    "github.com/gnoswap-labs/lint/internal"
+)
+
+type SimplifySliceExpressionFormatter struct{}
+
+func (f *SimplifySliceExpressionFormatter) Format(
+    issue internal.Issue,
+    snippet *internal.SourceCode,
+) string {
+    var result strings.Builder
+
+    lineNumberStr := fmt.Sprintf("%d", issue.Start.Line)
+    padding := strings.Repeat(" ", len(lineNumberStr)-1)
+    result.WriteString(lineStyle.Sprintf("  %s|\n", padding))
+
+    line := expandTabs(snippet.Lines[issue.Start.Line-1])
+    result.WriteString(lineStyle.Sprintf("%d | ", issue.Start.Line))
+    result.WriteString(line + "\n")
+
+    visualColumn := calculateVisualColumn(line, issue.Start.Column)
+    result.WriteString(lineStyle.Sprintf("  %s| ", padding))
+    result.WriteString(strings.Repeat(" ", visualColumn))
+    result.WriteString(messageStyle.Sprintf("^ %s\n\n", issue.Message))
+
+    result.WriteString(suggestionStyle.Sprintf("Suggestion:\n"))
+    result.WriteString(lineStyle.Sprintf("%d | ", issue.Start.Line))
+    result.WriteString(fmt.Sprintf("%s\n", issue.Suggestion))
+
+    result.WriteString(suggestionStyle.Sprint("Note: "))
+    result.WriteString(fmt.Sprintf("%s\n", issue.Message))
+
+    return result.String()
+}

--- a/formatter/simplify_slice_expr.go
+++ b/formatter/simplify_slice_expr.go
@@ -1,39 +1,35 @@
 package formatter
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 
-    "github.com/gnoswap-labs/lint/internal"
+	"github.com/gnoswap-labs/lint/internal"
 )
 
 type SimplifySliceExpressionFormatter struct{}
 
 func (f *SimplifySliceExpressionFormatter) Format(
-    issue internal.Issue,
-    snippet *internal.SourceCode,
+	issue internal.Issue,
+	snippet *internal.SourceCode,
 ) string {
-    var result strings.Builder
+	var result strings.Builder
 
-    lineNumberStr := fmt.Sprintf("%d", issue.Start.Line)
-    padding := strings.Repeat(" ", len(lineNumberStr)-1)
-    result.WriteString(lineStyle.Sprintf("  %s|\n", padding))
+	lineNumberStr := fmt.Sprintf("%d", issue.Start.Line)
+	padding := strings.Repeat(" ", len(lineNumberStr)-1)
+	result.WriteString(lineStyle.Sprintf("  %s|\n", padding))
 
-    line := expandTabs(snippet.Lines[issue.Start.Line-1])
-    result.WriteString(lineStyle.Sprintf("%d | ", issue.Start.Line))
-    result.WriteString(line + "\n")
+	line := expandTabs(snippet.Lines[issue.Start.Line-1])
+	result.WriteString(lineStyle.Sprintf("%d | ", issue.Start.Line))
+	result.WriteString(line + "\n")
 
-    visualColumn := calculateVisualColumn(line, issue.Start.Column)
-    result.WriteString(lineStyle.Sprintf("  %s| ", padding))
-    result.WriteString(strings.Repeat(" ", visualColumn))
-    result.WriteString(messageStyle.Sprintf("^ %s\n\n", issue.Message))
+	visualColumn := calculateVisualColumn(line, issue.Start.Column)
+	result.WriteString(lineStyle.Sprintf("  %s| ", padding))
+	result.WriteString(strings.Repeat(" ", visualColumn))
+	result.WriteString(messageStyle.Sprintf("^ %s\n\n", issue.Message))
 
-    result.WriteString(suggestionStyle.Sprintf("Suggestion:\n"))
-    result.WriteString(lineStyle.Sprintf("%d | ", issue.Start.Line))
-    result.WriteString(fmt.Sprintf("%s\n", issue.Suggestion))
+	buildSuggestion(&result, issue, lineStyle, suggestionStyle)
+	buildNote(&result, issue, suggestionStyle)
 
-    result.WriteString(suggestionStyle.Sprint("Note: "))
-    result.WriteString(fmt.Sprintf("%s\n", issue.Message))
-
-    return result.String()
+	return result.String()
 }

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -32,6 +32,7 @@ func (e *Engine) registerDefaultRules() {
 		&GolangciLintRule{},
 		&UnnecessaryElseRule{},
 		&UnusedFunctionRule{},
+		&SimplifySliceExprRule{},
 	)
 }
 

--- a/internal/lint.go
+++ b/internal/lint.go
@@ -38,7 +38,7 @@ type golangciOutput struct {
 }
 
 func runGolangciLint(filename string) ([]Issue, error) {
-	cmd := exec.Command("golangci-lint", "run", "--out-format=json", filename)
+	cmd := exec.Command("golangci-lint", "run", "--disable=gosimple", "--out-format=json", filename)
 	output, _ := cmd.CombinedOutput()
 
 	var golangciResult golangciOutput
@@ -197,11 +197,12 @@ func (e *Engine) detectUnnecessarySliceLength(filename string) ([]Issue, error) 
 						}
 
 						issue := Issue{
-							Rule: "unnecessary-slice-length",
+							Rule: "simplify-slice-range",
 							Filename: filename,
 							Start: fset.Position(sliceExpr.Pos()),
 							End: fset.Position(sliceExpr.End()),
-							Message: fmt.Sprintf("%s\nSuggestion: Use %s\n", baseMessage, suggestion),
+							Message: baseMessage,
+							Suggestion: suggestion,
 						}
 						issues = append(issues, issue)
 					}

--- a/internal/lint.go
+++ b/internal/lint.go
@@ -185,24 +185,35 @@ func (e *Engine) detectUnnecessarySliceLength(filename string) ([]Issue, error) 
 			if ident, ok := callExpr.Fun.(*ast.Ident); ok && ident.Name == "len" {
 				if arg, ok := callExpr.Args[0].(*ast.Ident); ok {
 					if sliceExpr.X.(*ast.Ident).Name == arg.Name {
-						var suggestion string
+						var suggestion, detailedMessage string
 						baseMessage := "unnecessary use of len() in slice expression, can be simplified"
 
 						if sliceExpr.Low == nil {
 							suggestion = fmt.Sprintf("%s[:]", arg.Name)
+							detailedMessage = fmt.Sprintf(
+								"%s\nIn this case, `%s[:len(%s)]` is equivalent to `%s[:]`. "+
+									"The full length of the slice is already implied when omitting both start and end indices.",
+								baseMessage, arg.Name, arg.Name, arg.Name)
 						} else if basicLit, ok := sliceExpr.Low.(*ast.BasicLit); ok {
 							suggestion = fmt.Sprintf("%s[%s:]", arg.Name, basicLit.Value)
+							detailedMessage = fmt.Sprintf("%s\nHere, `%s[%s:len(%s)]` can be simplified to `%s[%s:]`. "+
+								"When slicing to the end of a slice, using len() is unnecessary.",
+								baseMessage, arg.Name, basicLit.Value, arg.Name, arg.Name, basicLit.Value)
 						} else if lowIdent, ok := sliceExpr.Low.(*ast.Ident); ok {
 							suggestion = fmt.Sprintf("%s[%s:]", arg.Name, lowIdent.Name)
+							detailedMessage = fmt.Sprintf("%s\nIn this instance, `%s[%s:len(%s)]` can be written as `%s[%s:]`. "+
+								"The len() function is redundant when slicing to the end, regardless of the start index.",
+								baseMessage, arg.Name, lowIdent.Name, arg.Name, arg.Name, lowIdent.Name)
 						}
 
 						issue := Issue{
-							Rule: "simplify-slice-range",
-							Filename: filename,
-							Start: fset.Position(sliceExpr.Pos()),
-							End: fset.Position(sliceExpr.End()),
-							Message: baseMessage,
+							Rule:       "simplify-slice-range",
+							Filename:   filename,
+							Start:      fset.Position(sliceExpr.Pos()),
+							End:        fset.Position(sliceExpr.End()),
+							Message:    baseMessage,
 							Suggestion: suggestion,
+							Note:       detailedMessage,
 						}
 						issues = append(issues, issue)
 					}

--- a/internal/lint_test.go
+++ b/internal/lint_test.go
@@ -203,9 +203,10 @@ func TestDetectUnnecessarySliceLength(t *testing.T) {
 		name     string
 		code     string
 		expected int
+		message  string
 	}{
 		{
-			name: "No unnecessary slice length",
+			name: "suggests to use slice[:]",
 			code: `
 package main
 
@@ -214,6 +215,19 @@ func main() {
 	_ = slice[:len(slice)]
 }`,
 			expected: 1,
+			message: "unnecessary use of len() in slice expression, can be simplified\nSuggestion: Use slice[:]\n",
+		},
+		{
+			name: "suggests to use slice[a:]",
+			code: `
+package main
+
+func main() {
+	slice := []int{1, 2, 3}
+	_ = slice[1:len(slice)]
+}`,
+			expected: 1,
+			message: "unnecessary use of len() in slice expression, can be simplified\nSuggestion: Use slice[1:]\n",
 		},
 		{
 			name: "Unnecessary slice length",
@@ -249,7 +263,7 @@ func main() {
 					assert.Equal(t, "unnecessary-slice-length", issue.Rule)
 					assert.Equal(
 						t,
-						"unnecessary use of len() in slice expression, can be simplified to a[b:]",
+						tt.message,
 						issue.Message,
 					)
 				}

--- a/internal/lint_test.go
+++ b/internal/lint_test.go
@@ -199,6 +199,7 @@ func unused2() {
 }
 
 func TestDetectUnnecessarySliceLength(t *testing.T) {
+	baseMsg := "unnecessary use of len() in slice expression, can be simplified"
 	tests := []struct {
 		name     string
 		code     string
@@ -215,7 +216,7 @@ func main() {
 	_ = slice[:len(slice)]
 }`,
 			expected: 1,
-			message: "unnecessary use of len() in slice expression, can be simplified\nSuggestion: Use slice[:]\n",
+			message:  baseMsg,
 		},
 		{
 			name: "suggests to use slice[a:]",
@@ -227,7 +228,7 @@ func main() {
 	_ = slice[1:len(slice)]
 }`,
 			expected: 1,
-			message: "unnecessary use of len() in slice expression, can be simplified\nSuggestion: Use slice[1:]\n",
+			message:  baseMsg,
 		},
 		{
 			name: "Unnecessary slice length",
@@ -239,6 +240,19 @@ func main() {
 	_ = slice[:]
 }`,
 			expected: 0,
+		},
+		{
+			name: "slice[a:len(slice)] -> slice[a:] (a: variable)",
+			code: `
+package main
+
+func main() {
+	slice := []int{1, 2, 3}
+	a := 1
+	_ = slice[a:len(slice)]
+}`,
+			expected: 1,
+			message:  baseMsg,
 		},
 	}
 
@@ -260,7 +274,7 @@ func main() {
 
 			if len(issues) > 0 {
 				for _, issue := range issues {
-					assert.Equal(t, "unnecessary-slice-length", issue.Rule)
+					assert.Equal(t, "simplify-slice-range", issue.Rule)
 					assert.Equal(
 						t,
 						tt.message,

--- a/internal/types.go
+++ b/internal/types.go
@@ -14,4 +14,5 @@ type Issue struct {
 	Start    token.Position
 	End      token.Position
 	Message  string
+	Suggestion string
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -9,10 +9,11 @@ type SourceCode struct {
 
 // Issue represents a lint issue found in the code base.
 type Issue struct {
-	Rule     string
-	Filename string
-	Start    token.Position
-	End      token.Position
-	Message  string
+	Rule       string
+	Filename   string
+	Start      token.Position
+	End        token.Position
+	Message    string
 	Suggestion string
+	Note       string
 }

--- a/testdata/slice0.gno
+++ b/testdata/slice0.gno
@@ -1,11 +1,16 @@
 package slice
 
+var slice = []int{1, 2, 3}
+
 func foo() {
-	slice := []int{1, 2, 3}
 	_ = slice[1:len(slice)]
 }
 
 func bar() {
-	slice := []int{1, 2, 3}
 	_ = slice[:len(slice)]
+}
+
+func baz() {
+	a := 1
+	_ = slice[a:len(slice)]
 }

--- a/testdata/slice0.gno
+++ b/testdata/slice0.gno
@@ -1,0 +1,11 @@
+package slice
+
+func foo() {
+	slice := []int{1, 2, 3}
+	_ = slice[1:len(slice)]
+}
+
+func bar() {
+	slice := []int{1, 2, 3}
+	_ = slice[:len(slice)]
+}


### PR DESCRIPTION
Simplify expression when specifying lengths with the `len` function inside a slice.

Handling these cases:

```go
slice[:len(slice)] → slice[:]
slice[n:len(slice)] → slice[n:] // n: number literal
slice[a:len(slice)] → slice[a:] // a: variable
```

## Example

```go
package slice

var slice = []int{1, 2, 3}

func foo() {
	_ = slice[1:len(slice)]
}

func bar() {
	_ = slice[:len(slice)]
}

func baz() {
	a := 1
	_ = slice[a:len(slice)]
}
```

Linter result:

```plain
error: simplify-slice-range
 --> testdata/slice0.gno
  |
6 |         _ = slice[1:len(slice)]
  |      ^ unnecessary use of len() in slice expression, can be simplified

Suggestion:
6 | slice[1:]

Note: unnecessary use of len() in slice expression, can be simplified
Here, `slice[1:len(slice)]` can be simplified to `slice[1:]`. When slicing to the end of a slice, using len() is unnecessary.

error: simplify-slice-range
 --> testdata/slice0.gno
   |
10 |         _ = slice[:len(slice)]
   |      ^ unnecessary use of len() in slice expression, can be simplified

Suggestion:
10 | slice[:]

Note: unnecessary use of len() in slice expression, can be simplified
In this case, `slice[:len(slice)]` is equivalent to `slice[:]`. The full length of the slice is already implied when omitting both start and end indices.

error: simplify-slice-range
 --> testdata/slice0.gno
   |
15 |         _ = slice[a:len(slice)]
   |      ^ unnecessary use of len() in slice expression, can be simplified

Suggestion:
15 | slice[a:]

Note: unnecessary use of len() in slice expression, can be simplified
In this instance, `slice[a:len(slice)]` can be written as `slice[a:]`. The len() function is redundant when slicing to the end, regardless of the start index.
```