### PR TITLE
Add Unnecessary Type Conversion Lint Rule

### DIFF
--- a/formatter/fmt.go
+++ b/formatter/fmt.go
@@ -10,9 +10,9 @@ import (
 
 // rule set
 const (
-	UnnecessaryElse   = "unnecessary-else"
+	UnnecessaryElse     = "unnecessary-else"
 	UnnecessaryTypeConv = "unnecessary-type-conversion"
-	SimplifySliceExpr = "simplify-slice-range"
+	SimplifySliceExpr   = "simplify-slice-range"
 )
 
 // IssueFormatter is the interface that wraps the Format method.

--- a/formatter/fmt.go
+++ b/formatter/fmt.go
@@ -11,6 +11,7 @@ import (
 // rule set
 const (
 	UnnecessaryElse   = "unnecessary-else"
+	UnnecessaryTypeConv = "unnecessary-type-conversion"
 	SimplifySliceExpr = "simplify-slice-range"
 )
 
@@ -41,6 +42,8 @@ func getFormatter(rule string) IssueFormatter {
 		return &UnnecessaryElseFormatter{}
 	case SimplifySliceExpr:
 		return &SimplifySliceExpressionFormatter{}
+	case UnnecessaryTypeConv:
+		return &UnnecessaryConversionFormatter{}
 	default:
 		return &GeneralIssueFormatter{}
 	}

--- a/formatter/fmt.go
+++ b/formatter/fmt.go
@@ -43,7 +43,7 @@ func getFormatter(rule string) IssueFormatter {
 	case SimplifySliceExpr:
 		return &SimplifySliceExpressionFormatter{}
 	case UnnecessaryTypeConv:
-		return &UnnecessaryConversionFormatter{}
+		return &UnnecessaryTypeConversionFormatter{}
 	default:
 		return &GeneralIssueFormatter{}
 	}

--- a/formatter/fmt_test.go
+++ b/formatter/fmt_test.go
@@ -296,3 +296,43 @@ func main() {
 		})
 	}
 }
+
+func TestUnnecessaryTypeConversionFormatter(t *testing.T) {
+	formatter := &UnnecessaryTypeConversionFormatter{}
+	
+	issue := internal.Issue{
+		Rule:       "unnecessary-type-conversion",
+		Filename:   "test.go",
+		Start:      token.Position{Line: 5, Column: 10},
+		End:        token.Position{Line: 5, Column: 20},
+		Message:    "unnecessary type conversion",
+		Suggestion: "Remove the type conversion. Change `int(myInt)` to just `myInt`.",
+		Note:       "Unnecessary type conversions can make the code less readable and may slightly impact performance. They are safe to remove when the expression already has the desired type.",
+	}
+
+	snippet := &internal.SourceCode{
+		Lines: []string{
+			"package main",
+			"",
+			"func main() {",
+			"    myInt := 42",
+			"    result := int(myInt)",
+			"}",
+		},
+	}
+
+	expected := `  |
+5 |     result := int(myInt)
+  |          ^ unnecessary type conversion
+
+Suggestion:
+5 | Remove the type conversion. Change ` + "`int(myInt)`" + ` to just ` + "`myInt`" + `.
+
+Note: Unnecessary type conversions can make the code less readable and may slightly impact performance. They are safe to remove when the expression already has the desired type.
+
+`
+
+	result := formatter.Format(issue, snippet)
+
+	assert.Equal(t, expected, result, "Formatted output should match expected output")
+}

--- a/formatter/fmt_test.go
+++ b/formatter/fmt_test.go
@@ -299,7 +299,7 @@ func main() {
 
 func TestUnnecessaryTypeConversionFormatter(t *testing.T) {
 	formatter := &UnnecessaryTypeConversionFormatter{}
-	
+
 	issue := internal.Issue{
 		Rule:       "unnecessary-type-conversion",
 		Filename:   "test.go",

--- a/formatter/unnecessary_type_conv.go
+++ b/formatter/unnecessary_type_conv.go
@@ -1,0 +1,71 @@
+package formatter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gnoswap-labs/lint/internal"
+)
+
+// UnnecessaryConversionFormatter formats unnecessary conversion issues.
+type UnnecessaryConversionFormatter struct{}
+
+func (f *UnnecessaryConversionFormatter) Format(
+	issue internal.Issue,
+	snippet *internal.SourceCode,
+) string {
+	var result strings.Builder
+
+	lineNumberStr := fmt.Sprintf("%d", issue.Start.Line)
+	padding := strings.Repeat(" ", len(lineNumberStr)-1)
+	result.WriteString(lineStyle.Sprintf("  %s|\n", padding))
+
+	// Get the problematic line
+	line := snippet.Lines[issue.Start.Line-1]
+	
+	// Write the line number and content
+	result.WriteString(lineStyle.Sprintf("%d | ", issue.Start.Line))
+	result.WriteString(line + "\n")
+
+	// Calculate the position for the error indicator
+	arrowPos := strings.Repeat(" ", issue.Start.Column-1)
+	
+	// Write the error indicator
+	result.WriteString(lineStyle.Sprintf("  | "))
+	result.WriteString(arrowPos)
+	result.WriteString(messageStyle.Sprintf("^ unnecessary conversion\n"))
+
+	// Add explanation and suggestion
+	result.WriteString("\n")
+	result.WriteString(suggestionStyle.Sprint("Suggestion: "))
+	result.WriteString("Remove the unnecessary type conversion.\n")
+	
+	// Try to provide a code suggestion
+	suggestion := f.generateSuggestion(line, issue.Start.Column-1, issue.End.Column-1)
+	if suggestion != "" {
+		result.WriteString("Consider changing the code to:\n")
+		result.WriteString(suggestionStyle.Sprintf("%s\n", suggestion))
+	}
+
+	result.WriteString("\n")
+
+	return result.String()
+}
+
+func (f *UnnecessaryConversionFormatter) generateSuggestion(line string, start, end int) string {
+	// This is a simple suggestion generator and might not work for all cases
+	// A more robust solution would involve parsing the AST
+	before := line[:start]
+	conversionPart := line[start:end]
+	after := line[end:]
+
+	// Try to remove the type conversion
+	parts := strings.SplitN(conversionPart, "(", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+
+	innerPart := strings.TrimRight(parts[1], ")")
+	
+	return before + innerPart + after
+}

--- a/formatter/unnecessary_type_conv.go
+++ b/formatter/unnecessary_type_conv.go
@@ -7,10 +7,9 @@ import (
 	"github.com/gnoswap-labs/lint/internal"
 )
 
-// UnnecessaryConversionFormatter formats unnecessary conversion issues.
-type UnnecessaryConversionFormatter struct{}
+type UnnecessaryTypeConversionFormatter struct{}
 
-func (f *UnnecessaryConversionFormatter) Format(
+func (f *UnnecessaryTypeConversionFormatter) Format(
 	issue internal.Issue,
 	snippet *internal.SourceCode,
 ) string {
@@ -20,52 +19,17 @@ func (f *UnnecessaryConversionFormatter) Format(
 	padding := strings.Repeat(" ", len(lineNumberStr)-1)
 	result.WriteString(lineStyle.Sprintf("  %s|\n", padding))
 
-	// Get the problematic line
-	line := snippet.Lines[issue.Start.Line-1]
-	
-	// Write the line number and content
+	line := expandTabs(snippet.Lines[issue.Start.Line-1])
 	result.WriteString(lineStyle.Sprintf("%d | ", issue.Start.Line))
 	result.WriteString(line + "\n")
 
-	// Calculate the position for the error indicator
-	arrowPos := strings.Repeat(" ", issue.Start.Column-1)
-	
-	// Write the error indicator
-	result.WriteString(lineStyle.Sprintf("  | "))
-	result.WriteString(arrowPos)
-	result.WriteString(messageStyle.Sprintf("^ unnecessary conversion\n"))
+	visualColumn := calculateVisualColumn(line, issue.Start.Column)
+	result.WriteString(lineStyle.Sprintf("  %s| ", padding))
+	result.WriteString(strings.Repeat(" ", visualColumn))
+	result.WriteString(messageStyle.Sprintf("^ %s\n\n", issue.Message))
 
-	// Add explanation and suggestion
-	result.WriteString("\n")
-	result.WriteString(suggestionStyle.Sprint("Suggestion: "))
-	result.WriteString("Remove the unnecessary type conversion.\n")
-	
-	// Try to provide a code suggestion
-	suggestion := f.generateSuggestion(line, issue.Start.Column-1, issue.End.Column-1)
-	if suggestion != "" {
-		result.WriteString("Consider changing the code to:\n")
-		result.WriteString(suggestionStyle.Sprintf("%s\n", suggestion))
-	}
-
-	result.WriteString("\n")
+	buildSuggestion(&result, issue, lineStyle, suggestionStyle)
+	buildNote(&result, issue, suggestionStyle)
 
 	return result.String()
-}
-
-func (f *UnnecessaryConversionFormatter) generateSuggestion(line string, start, end int) string {
-	// This is a simple suggestion generator and might not work for all cases
-	// A more robust solution would involve parsing the AST
-	before := line[:start]
-	conversionPart := line[start:end]
-	after := line[end:]
-
-	// Try to remove the type conversion
-	parts := strings.SplitN(conversionPart, "(", 2)
-	if len(parts) != 2 {
-		return ""
-	}
-
-	innerPart := strings.TrimRight(parts[1], ")")
-	
-	return before + innerPart + after
 }

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -33,6 +33,7 @@ func (e *Engine) registerDefaultRules() {
 		&UnnecessaryElseRule{},
 		&UnusedFunctionRule{},
 		&SimplifySliceExprRule{},
+		&UnnecessaryConversionRule{},
 	)
 }
 

--- a/internal/lint.go
+++ b/internal/lint.go
@@ -245,14 +245,11 @@ func (e *Engine) detectUnnecessaryConversions(filename string) ([]Issue, error) 
 
 	info := &types.Info{
 		Types: make(map[ast.Expr]types.TypeAndValue),
-		Uses: make(map[*ast.Ident]types.Object),
+		Uses:  make(map[*ast.Ident]types.Object),
 	}
 
-	conf := types.Config{ Importer: importer.Default() }
-	_, err = conf.Check("", fset, []*ast.File{f}, info)
-	if err != nil {
-		return nil, err
-	}
+	conf := types.Config{Importer: importer.Default()}
+	conf.Check("", fset, []*ast.File{f}, info)
 
 	var issues []Issue
 	ast.Inspect(f, func(n ast.Node) bool {
@@ -282,10 +279,10 @@ func (e *Engine) detectUnnecessaryConversions(filename string) ([]Issue, error) 
 				Start:    fset.Position(call.Pos()),
 				End:      fset.Position(call.End()),
 				Message:  "unnecessary type conversion",
-				Suggestion: fmt.Sprintf("Remove the type conversion. Change `%s(%s)` to just `%s`.", 
-				types.TypeString(ft.Type, nil), 
-				types.TypeString(at.Type, nil),
-				types.TypeString(at.Type, nil)),
+				Suggestion: fmt.Sprintf("Remove the type conversion. Change `%s(%s)` to just `%s`.",
+					types.TypeString(ft.Type, nil),
+					types.TypeString(at.Type, nil),
+					types.TypeString(at.Type, nil)),
 			})
 		}
 

--- a/internal/lint.go
+++ b/internal/lint.go
@@ -282,6 +282,10 @@ func (e *Engine) detectUnnecessaryConversions(filename string) ([]Issue, error) 
 				Start:    fset.Position(call.Pos()),
 				End:      fset.Position(call.End()),
 				Message:  "unnecessary type conversion",
+				Suggestion: fmt.Sprintf("Remove the type conversion. Change `%s(%s)` to just `%s`.", 
+				types.TypeString(ft.Type, nil), 
+				types.TypeString(at.Type, nil),
+				types.TypeString(at.Type, nil)),
 			})
 		}
 

--- a/internal/lint.go
+++ b/internal/lint.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/ast"
+	"go/importer"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"os/exec"
 )
 
@@ -225,4 +227,142 @@ func (e *Engine) detectUnnecessarySliceLength(filename string) ([]Issue, error) 
 	})
 
 	return issues, nil
+}
+
+type UnnecessaryConversionRule struct{}
+
+func (r *UnnecessaryConversionRule) Check(filename string) ([]Issue, error) {
+	engine := &Engine{}
+	return engine.detectUnnecessaryConversions(filename)
+}
+
+func (e *Engine) detectUnnecessaryConversions(filename string) ([]Issue, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+		Uses: make(map[*ast.Ident]types.Object),
+	}
+
+	conf := types.Config{ Importer: importer.Default() }
+	_, err = conf.Check("", fset, []*ast.File{f}, info)
+	if err != nil {
+		return nil, err
+	}
+
+	var issues []Issue
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		if len(call.Args) != 1 {
+			return true
+		}
+
+		ft, ok := info.Types[call.Fun]
+		if !ok || !ft.IsType() {
+			return true
+		}
+
+		at, ok := info.Types[call.Args[0]]
+		if !ok {
+			return true
+		}
+
+		if types.Identical(ft.Type, at.Type) && !isUntypedValue(call.Args[0], info) {
+			issues = append(issues, Issue{
+				Rule:     "unnecessary-type-conversion",
+				Filename: filename,
+				Start:    fset.Position(call.Pos()),
+				End:      fset.Position(call.End()),
+				Message:  "unnecessary type conversion",
+			})
+		}
+
+		return true
+	})
+
+	return issues, nil
+}
+
+// ref: https://github.com/mdempsky/unconvert/blob/master/unconvert.go#L570
+func isUntypedValue(n ast.Expr, info *types.Info) (res bool) {
+	switch n := n.(type) {
+	case *ast.BinaryExpr:
+		switch n.Op {
+		case token.SHL, token.SHR:
+			// Shifts yield an untyped value if their LHS is untyped.
+			return isUntypedValue(n.X, info)
+		case token.EQL, token.NEQ, token.LSS, token.GTR, token.LEQ, token.GEQ:
+			// Comparisons yield an untyped boolean value.
+			return true
+		case token.ADD, token.SUB, token.MUL, token.QUO, token.REM,
+			token.AND, token.OR, token.XOR, token.AND_NOT,
+			token.LAND, token.LOR:
+			return isUntypedValue(n.X, info) && isUntypedValue(n.Y, info)
+		}
+	case *ast.UnaryExpr:
+		switch n.Op {
+		case token.ADD, token.SUB, token.NOT, token.XOR:
+			return isUntypedValue(n.X, info)
+		}
+	case *ast.BasicLit:
+		// Basic literals are always untyped.
+		return true
+	case *ast.ParenExpr:
+		return isUntypedValue(n.X, info)
+	case *ast.SelectorExpr:
+		return isUntypedValue(n.Sel, info)
+	case *ast.Ident:
+		if obj, ok := info.Uses[n]; ok {
+			if obj.Pkg() == nil && obj.Name() == "nil" {
+				// The universal untyped zero value.
+				return true
+			}
+			if b, ok := obj.Type().(*types.Basic); ok && b.Info()&types.IsUntyped != 0 {
+				// Reference to an untyped constant.
+				return true
+			}
+		}
+	case *ast.CallExpr:
+		if b, ok := asBuiltin(n.Fun, info); ok {
+			switch b.Name() {
+			case "real", "imag":
+				return isUntypedValue(n.Args[0], info)
+			case "complex":
+				return isUntypedValue(n.Args[0], info) && isUntypedValue(n.Args[1], info)
+			}
+		}
+	}
+
+	return false
+}
+
+func asBuiltin(n ast.Expr, info *types.Info) (*types.Builtin, bool) {
+	for {
+		paren, ok := n.(*ast.ParenExpr)
+		if !ok {
+			break
+		}
+		n = paren.X
+	}
+
+	ident, ok := n.(*ast.Ident)
+	if !ok {
+		return nil, false
+	}
+
+	obj, ok := info.Uses[ident]
+	if !ok {
+		return nil, false
+	}
+
+	b, ok := obj.(*types.Builtin)
+	return b, ok
 }

--- a/testdata/conv0.gno
+++ b/testdata/conv0.gno
@@ -1,0 +1,11 @@
+package main
+
+func example() {
+    var x int = 5
+    y := int(x)
+    _ = y
+}
+
+func main() {
+	example()
+}

--- a/testdata/conv0.gno
+++ b/testdata/conv0.gno
@@ -3,7 +3,8 @@ package main
 func example() {
     var x int = 5
     y := int(x)
-    _ = y
+    z := string(y)
+    println(z)
 }
 
 func main() {

--- a/testdata/demo.gno
+++ b/testdata/demo.gno
@@ -11,10 +11,12 @@ func foo(x, y bool) int {
 }
 
 func bar() {
+	x := 5
 	println("hello")
 }
 
 func main() {
 	x := foo(true)
+	bar()
 	println(x)
 }

--- a/testdata/demo.gno
+++ b/testdata/demo.gno
@@ -11,7 +11,6 @@ func foo(x, y bool) int {
 }
 
 func bar() {
-	x := 5
 	println("hello")
 }
 


### PR DESCRIPTION
# Description

Implemented `UnnecessaryConversionRule` to detect redundant type conversions. This rule identifies cases where a variable is converted to its own type.