### PR TITLE
feat: Detect useless break

### DIFF
--- a/internal/engine.go
+++ b/internal/engine.go
@@ -42,6 +42,7 @@ func (e *Engine) registerDefaultRules() {
 		&EmitFormatRule{},
 		&DetectCycleRule{},
 		&GnoSpecificRule{},
+		&UselessBreakRule{},
 	)
 }
 

--- a/internal/lints/useless_break.go
+++ b/internal/lints/useless_break.go
@@ -1,0 +1,49 @@
+package lints
+
+import (
+	"go/ast"
+	"go/token"
+
+	tt "github.com/gnoswap-labs/lint/internal/types"
+)
+
+// DetectUselessBreak detects useless break statements in switch or select statements.
+func DetectUselessBreak(filename string, node *ast.File, fset *token.FileSet) ([]tt.Issue, error) {
+	var issues []tt.Issue
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.SwitchStmt:
+			for _, stmt := range v.Body.List {
+				if caseClause, ok := stmt.(*ast.CaseClause); ok {
+					checkUselessBreak(caseClause.Body, filename, fset, &issues)
+				}
+			}
+		case *ast.SelectStmt:
+			for _, stmt := range v.Body.List {
+				if commClause, ok := stmt.(*ast.CommClause); ok {
+					checkUselessBreak(commClause.Body, filename, fset, &issues)
+				}
+			}
+		}
+		return true
+	})
+
+	return issues, nil
+}
+
+func checkUselessBreak(stmts []ast.Stmt, filename string, fset *token.FileSet, issues *[]tt.Issue) {
+	if len(stmts) == 0 {
+		return
+	}
+
+	lastStmt := stmts[len(stmts)-1]
+	if breakStmt, ok := lastStmt.(*ast.BranchStmt); ok && breakStmt.Tok == token.BREAK && breakStmt.Label == nil {
+		*issues = append(*issues, tt.Issue{
+			Rule:     "useless-break",
+			Filename: filename,
+			Start:    fset.Position(breakStmt.Pos()),
+			End:      fset.Position(breakStmt.End()),
+			Message:  "useless break statement at the end of case clause",
+		})
+	}
+}

--- a/internal/rule_set.go
+++ b/internal/rule_set.go
@@ -101,6 +101,16 @@ func (r *SliceBoundCheckRule) Name() string {
 	return "slice-bounds-check"
 }
 
+type UselessBreakRule struct{}
+
+func (r *UselessBreakRule) Check(filename string, node *ast.File, fset *token.FileSet) ([]tt.Issue, error) {
+	return lints.DetectUselessBreak(filename, node, fset)
+}
+
+func (r *UselessBreakRule) Name() string {
+	return "useless-break"
+}
+
 // -----------------------------------------------------------------------------
 
 type CyclomaticComplexityRule struct {

--- a/testdata/break/break0.gno
+++ b/testdata/break/break0.gno
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	switch x := 1; x {
+	case 1:
+		println("one")
+	case 2:
+		println("two")
+	default:
+		println("other")
+	}
+}

--- a/testdata/break/break1.gno
+++ b/testdata/break/break1.gno
@@ -1,0 +1,14 @@
+package main
+
+func main() {
+	switch x := 1; x {
+	case 1:
+		println("one")
+		break
+	case 2:
+		println("two")
+	default:
+		println("other")
+		break
+	}
+}

--- a/testdata/break/break2.gno
+++ b/testdata/break/break2.gno
@@ -1,0 +1,14 @@
+package main
+
+func main() {
+outer:
+	for {
+		switch x := 1; x {
+		case 1:
+			println("one")
+			break outer
+		case 2:
+			println("two")
+		}
+	}
+}


### PR DESCRIPTION
# Description

Add new lint rule to detect useless break statement in `switch` and `select` (go specific) clauses.

## Details

This lint works as follows:

1. It traverses the AST of the given file.
2. For each switch or select statement encountered:
    - It examines each case clause.
    - If the last statement in a case clause is an unabled break, it's flagged as useless.
3. Each useless break detected is reported.

## Covered Scenarios

- No useless breaks
- Useless breaks in switch statements
- Useless breaks in select statements
- Labeled breaks (which are not considered useless)