### PR TITLE
feat: Issue-Specific Header Type

### DIFF
--- a/formatter/builder.go
+++ b/formatter/builder.go
@@ -105,9 +105,13 @@ func (b *IssueFormatterBuilder) AddHeader(kind headerType) *IssueFormatterBuilde
 	}
 
 	b.result.WriteString(ruleStyle.Sprintln(b.issue.Rule))
+	
+	endLine := b.issue.End.Line
+	maxLineNumWidth := calculateMaxLineNumWidth(endLine)
+	padding := strings.Repeat(" ", maxLineNumWidth)
 
 	// add file name
-	b.result.WriteString(lineStyle.Sprint(" --> "))
+	b.result.WriteString(lineStyle.Sprint(fmt.Sprintf("%s--> ", padding)))
 	b.result.WriteString(fileStyle.Sprintln(b.issue.Filename))
 
 	return b

--- a/formatter/builder.go
+++ b/formatter/builder.go
@@ -11,7 +11,7 @@ import (
 
 // rule set
 const (
-	EarlyReturn 	   = "early-return"
+	EarlyReturn         = "early-return"
 	UnnecessaryTypeConv = "unnecessary-type-conversion"
 	SimplifySliceExpr   = "simplify-slice-range"
 	CycloComplexity     = "high-cyclomatic-complexity"
@@ -86,9 +86,24 @@ func NewIssueFormatterBuilder(issue tt.Issue, snippet *internal.SourceCode) *Iss
 	}
 }
 
-func (b *IssueFormatterBuilder) AddHeader() *IssueFormatterBuilder {
-	// add error type and rule name
-	b.result.WriteString(errorStyle.Sprint("error: "))
+// headerType represents the type of header to be added to the formatted issue.
+// The header can be either a warning or an error.
+type headerType int
+
+const (
+	warningHeader headerType = iota
+	errorHeader
+)
+
+func (b *IssueFormatterBuilder) AddHeader(kind headerType) *IssueFormatterBuilder {
+	// add header type and rule name
+	switch kind {
+	case errorHeader:
+		b.result.WriteString(errorStyle.Sprint("error: "))
+	case warningHeader:
+		b.result.WriteString(warningStyle.Sprint("warning: "))
+	}
+
 	b.result.WriteString(ruleStyle.Sprintln(b.issue.Rule))
 
 	// add file name
@@ -190,7 +205,7 @@ type BaseFormatter struct{}
 func (f *BaseFormatter) Format(issue tt.Issue, snippet *internal.SourceCode) string {
 	builder := NewIssueFormatterBuilder(issue, snippet)
 	return builder.
-		AddHeader().
+		AddHeader(warningHeader).
 		AddCodeSnippet().
 		AddUnderlineAndMessage().
 		AddSuggestion().
@@ -239,14 +254,4 @@ func calculateVisualColumn(line string, column int) int {
 		}
 	}
 	return visualColumn
-}
-
-func calculateMaxLineLength(lines []string, start, end int) int {
-	maxLen := 0
-	for i := start - 1; i < end; i++ {
-		if len(lines[i]) > maxLen {
-			maxLen = len(lines[i])
-		}
-	}
-	return maxLen
 }

--- a/formatter/cyclomatic_complexity.go
+++ b/formatter/cyclomatic_complexity.go
@@ -13,7 +13,7 @@ type CyclomaticComplexityFormatter struct{}
 func (f *CyclomaticComplexityFormatter) Format(issue tt.Issue, snippet *internal.SourceCode) string {
 	builder := NewIssueFormatterBuilder(issue, snippet)
 	return builder.
-		AddHeader().
+		AddHeader(warningHeader).
 		AddCodeSnippet().
 		AddComplexityInfo().
 		AddSuggestion().

--- a/formatter/early_return.go
+++ b/formatter/early_return.go
@@ -10,7 +10,7 @@ type EarlyReturnOpportunityFormatter struct{}
 func (f *EarlyReturnOpportunityFormatter) Format(issue tt.Issue, snippet *internal.SourceCode) string {
 	builder := NewIssueFormatterBuilder(issue, snippet)
 	return builder.
-		AddHeader().
+		AddHeader(warningHeader).
 		AddCodeSnippet().
 		AddUnderlineAndMessage().
 		AddSuggestion().

--- a/formatter/format_emit.go
+++ b/formatter/format_emit.go
@@ -10,7 +10,7 @@ type EmitFormatFormatter struct{}
 func (f *EmitFormatFormatter) Format(issue tt.Issue, snippet *internal.SourceCode) string {
 	builder := NewIssueFormatterBuilder(issue, snippet)
 	return builder.
-		AddHeader().
+		AddHeader(errorHeader).
 		AddCodeSnippet().
 		AddUnderlineAndMessage().
 		AddSuggestion().

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -148,7 +148,7 @@ error: empty-if
   | empty branch
 
 error: example
- --> test.go
+  --> test.go
    |
 10 |     println("end")
    |     ~~~~~~~~

--- a/formatter/general.go
+++ b/formatter/general.go
@@ -16,7 +16,7 @@ func (f *GeneralIssueFormatter) Format(
 ) string {
 	builder := NewIssueFormatterBuilder(issue, snippet)
 	return builder.
-		AddHeader().
+		AddHeader(errorHeader).
 		AddCodeSnippet().
 		AddUnderlineAndMessage().
 		Build()

--- a/formatter/simplify_slice_expr.go
+++ b/formatter/simplify_slice_expr.go
@@ -10,7 +10,7 @@ type SimplifySliceExpressionFormatter struct{}
 func (f *SimplifySliceExpressionFormatter) Format(issue tt.Issue, snippet *internal.SourceCode) string {
 	builder := NewIssueFormatterBuilder(issue, snippet)
 	return builder.
-		AddHeader().
+		AddHeader(errorHeader).
 		AddCodeSnippet().
 		AddUnderlineAndMessage().
 		AddSuggestion().

--- a/formatter/slice_bound.go
+++ b/formatter/slice_bound.go
@@ -13,7 +13,7 @@ func (f *SliceBoundsCheckFormatter) Format(
 ) string {
 	builder := NewIssueFormatterBuilder(issue, snippet)
 	return builder.
-		AddHeader().
+		AddHeader(errorHeader).
 		AddCodeSnippet().
 		AddUnderlineAndMessage().
 		AddWarning().

--- a/formatter/unnecessary_type_conv.go
+++ b/formatter/unnecessary_type_conv.go
@@ -10,7 +10,7 @@ type UnnecessaryTypeConversionFormatter struct{}
 func (f *UnnecessaryTypeConversionFormatter) Format(issue tt.Issue, snippet *internal.SourceCode) string {
 	builder := NewIssueFormatterBuilder(issue, snippet)
 	return builder.
-		AddHeader().
+		AddHeader(errorHeader).
 		AddCodeSnippet().
 		AddUnderlineAndMessage().
 		AddSuggestion().


### PR DESCRIPTION
 # Description

Defined `headerType` for each issue to show their importance. Currently, 2 types have been added: `warnign` and `error`.

The `warning` type is applied to common lints that are not major problems. The `error` type is used when rendering lint rules related to golangci-lint or memory issues.